### PR TITLE
Fix build script error for libjpeg-turbo

### DIFF
--- a/data/libjpeg-turbo/build.sh
+++ b/data/libjpeg-turbo/build.sh
@@ -19,7 +19,6 @@ function download() {
     else
         git clone --depth 1 https://github.com/libjpeg-turbo/libjpeg-turbo.git
         git clone --depth 1 https://github.com/libjpeg-turbo/seed-corpora
-        mv libjpeg-turbo ${PROJECT_NAME}
         mv seed-corpora ${PROJECT_NAME}
     fi
 }


### PR DESCRIPTION
The script moves `libjpeg-turbo` to existing `libjpeg-turbo`, which causes a error:

```
mv: cannot move 'libjpeg-turbo' to a subdirectory of itself, 'libjpeg-turbo/libjpeg-turbo'
```