### PR TITLE
Detect empty gadgets

### DIFF
--- a/src/program/gadget.rs
+++ b/src/program/gadget.rs
@@ -46,6 +46,9 @@ pub fn get_func_gadgets() -> &'static Vec<FuncGadget> {
         }
         func_gadget::dump_func_gadgets(&gadgets, &deopt).unwrap();
         log::debug!("Parsed {} function gadgets.", gadgets.len());
+        if gadgets.is_empty() {
+            panic!("Cannot extract function gadgets! Please check whether your library building was sucessful!")
+        }
         gadgets
     })
 }


### PR DESCRIPTION
Add an annotations report when no function gadgets were extracted from the library building gadgets.

When you reach this case, you should check whether your building script was successfully executed and whether header files ".h" or ".hpp" are placed in the src/output/build/xxx/include directory.